### PR TITLE
[26-12-create-card-decks] added deck class and tests

### DIFF
--- a/monopoly/src/main/java/gameset/cards/Card.java
+++ b/monopoly/src/main/java/gameset/cards/Card.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import gameset.functionality.Game;
 import gameset.functionality.Player;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * Abstract class representing a card in the game.
@@ -24,6 +25,17 @@ public abstract class Card {
         this.action = action;
         this.description = description;
         this.params = params;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (!(o instanceof Card card)) return false;
+        return action == card.action && Objects.equals(description, card.description) && Objects.equals(params, card.params);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(action, description, params);
     }
 
     public abstract void applyEffect(Player p, Game g);

--- a/monopoly/src/main/java/gameset/functionality/Board.java
+++ b/monopoly/src/main/java/gameset/functionality/Board.java
@@ -9,17 +9,16 @@ import java.util.ArrayList;
 
 public class Board {
     private final ArrayList<Property> gameBoard;
-    // TODO: GH issue #26 (Card decks - explore Collections.shuffle method or create Deck class)
-    private ArrayList<ChanceCard> chanceCards;
-    private ArrayList<CommunityChestCard> communityChestCards;
+    private Deck<ChanceCard> chanceCards;
+    private Deck<CommunityChestCard> communityChestCards;
 
     public Board() throws IOException {
         ResourceParser propertyParser = new ResourceParser("/models/propertyData.json");
         ResourceParser chanceCardParser = new ResourceParser("/models/chanceData.json");
         ResourceParser communityChestCardParser = new ResourceParser("/models/communityData.json");
         this.gameBoard = propertyParser.parseJsonToArrayList(Property.class);
-        this.chanceCards = chanceCardParser.parseJsonToArrayList(ChanceCard.class);
-        this.communityChestCards = communityChestCardParser.parseJsonToArrayList(CommunityChestCard.class);
+        this.chanceCards = new Deck<>(chanceCardParser.parseJsonToArrayList(ChanceCard.class));
+        this.communityChestCards = new Deck<>(communityChestCardParser.parseJsonToArrayList(CommunityChestCard.class));
     }
 
     public ArrayList<Property> getGameBoard() {

--- a/monopoly/src/main/java/gameset/functionality/Deck.java
+++ b/monopoly/src/main/java/gameset/functionality/Deck.java
@@ -5,9 +5,19 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+/**
+ * Class representing a deck of cards.
+ *
+ * Includes methods for shuffling, drawing, and adding cards to top or bottom of the deck.
+ */
 public class Deck<T extends Card> {
     ArrayList<T> deck;
 
+    /**
+     * Creates a new deck of cards.
+     *
+     * @param cards the cards to add to the deck
+     */
     public Deck(List<T> cards) {
         this.deck = (ArrayList<T>) cards;
     }

--- a/monopoly/src/main/java/gameset/functionality/Deck.java
+++ b/monopoly/src/main/java/gameset/functionality/Deck.java
@@ -1,0 +1,95 @@
+package gameset.functionality;
+
+import gameset.cards.Card;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public class Deck<T extends Card> {
+    ArrayList<T> deck;
+
+    public Deck(List<T> cards) {
+        this.deck = (ArrayList<T>) cards;
+    }
+
+    /**
+     * Randomizes the order of the cards in the deck.
+     */
+    public void shuffle() {
+        Collections.shuffle(this.deck);
+    }
+
+    /**
+     * Removes and returns the card at the top of the deck.
+     *
+     * @return the card at the top of the deck
+     */
+    public T draw() {
+        return this.deck.removeFirst();
+    }
+
+    /**
+     * Adds a card to the bottom of the deck.
+     *
+     * @param card the card to add
+     */
+    public void addToBottom(T card) {
+        this.deck.add(card);
+    }
+
+    /**
+     * Adds a card to the top of the deck.
+     *
+     * @param card the card to add
+     */
+    public void addToTop(T card) {
+        this.deck.addFirst(card);
+    }
+
+    /**
+     * Returns the card at the top of the deck without removing it.
+     *
+     * @return the card at the top of the deck
+     */
+    public T peek() {
+        return this.deck.getFirst();
+    }
+
+    /**
+     * Returns the card at the specified index without removing it.
+     *
+     * @param index the index of the card to return
+     * @return the card at the specified index
+     */
+    public T peek(int index) {
+        return this.deck.get(index);
+    }
+
+    /**
+     * Removes a card from the deck.
+     *
+     * @param card the card to remove
+     * @return true if the card was found and removed, false otherwise
+     */
+    public boolean removeCard(T card) {
+        return this.deck.remove(card);
+    }
+
+    /**
+     * Returns the number of cards in the deck.
+     *
+     * @return the number of cards in the deck
+     */
+    public int size() {
+        return this.deck.size();
+    }
+
+    /**
+     * Returns the underlying deck of cards. Utilize for testing.
+     *
+     * @return the deck of cards
+     */
+    public ArrayList<T> getDeck() {
+        return this.deck;
+    }
+}

--- a/monopoly/src/test/java/gameset/functionality/deck/DeckTest.java
+++ b/monopoly/src/test/java/gameset/functionality/deck/DeckTest.java
@@ -1,0 +1,121 @@
+package gameset.functionality.deck;
+
+import gameset.cards.Action;
+import gameset.cards.Card;
+import gameset.cards.ChanceCard;
+import gameset.functionality.Deck;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class DeckTest {
+    @Test
+    public void testDeckConstructorEmpty() {
+        Deck deck = new Deck(new ArrayList<>());
+        assertEquals(0, deck.size());
+    }
+
+    @Test
+    public void testDeckConstructorWithCards() {
+        ArrayList<Card> cards = new ArrayList<>();
+        cards.add(new ChanceCard(Action.Advance, "Test card 1", new HashMap<>()));
+        cards.add(new ChanceCard(Action.DirectMove, "Test card 2", new HashMap<>()));
+        Deck deck = new Deck(cards);
+        assertEquals(2, deck.size());
+    }
+
+    // NOTE: it is possible for this test to fail given that shuffle is random.
+    // There is a chance that the order of the cards will be the same.
+    @Test
+    public void testShuffle() {
+        ArrayList<Card> cards = new ArrayList<>();
+        cards.add(new ChanceCard(Action.Advance, "Test card 1", new HashMap<>()));
+        cards.add(new ChanceCard(Action.DirectMove, "Test card 2", new HashMap<>()));
+        cards.add(new ChanceCard(Action.DirectMove, "Test card 3", new HashMap<>()));
+        cards.add(new ChanceCard(Action.DirectMove, "Test card 4", new HashMap<>()));
+        cards.add(new ChanceCard(Action.DirectMove, "Test card 5", new HashMap<>()));
+        cards.add(new ChanceCard(Action.DirectMove, "Test card 6", new HashMap<>()));
+        cards.add(new ChanceCard(Action.DirectMove, "Test card 7", new HashMap<>()));
+        Deck deck = new Deck(cards);
+        ArrayList<Card> initialOrder = new ArrayList<>(deck.getDeck());
+        deck.shuffle();
+        ArrayList<Card> shuffledOrder = new ArrayList<>(deck.getDeck());
+        assertNotEquals(initialOrder, shuffledOrder);
+    }
+
+    @Test
+    public void testDraw() {
+        ArrayList<Card> cards = new ArrayList<>();
+        cards.add(new ChanceCard(Action.Advance, "Test card 1", new HashMap<>()));
+        cards.add(new ChanceCard(Action.DirectMove, "Test card 2", new HashMap<>()));
+        cards.add(new ChanceCard(Action.DirectMove, "Test card 3", new HashMap<>()));
+        Deck deck = new Deck(cards);
+        Card card1 = deck.draw();
+        assertEquals(new ChanceCard(Action.Advance, "Test card 1", new HashMap<>()), card1);
+        assertEquals(2, deck.size());
+    }
+
+    @Test
+    public void testPeek() {
+        ArrayList<Card> cards = new ArrayList<>();
+        cards.add(new ChanceCard(Action.Advance, "Test card 1", new HashMap<>()));
+        cards.add(new ChanceCard(Action.DirectMove, "Test card 2", new HashMap<>()));
+        cards.add(new ChanceCard(Action.DirectMove, "Test card 3", new HashMap<>()));
+        Deck deck = new Deck(cards);
+        Card card1 = deck.peek();
+        assertEquals(new ChanceCard(Action.Advance, "Test card 1", new HashMap<>()), card1);
+        assertEquals(3, deck.size());
+    }
+
+    @Test
+    public void testPeekIndex() {
+        ArrayList<Card> cards = new ArrayList<>();
+        cards.add(new ChanceCard(Action.Advance, "Test card 1", new HashMap<>()));
+        cards.add(new ChanceCard(Action.DirectMove, "Test card 2", new HashMap<>()));
+        cards.add(new ChanceCard(Action.DirectMove, "Test card 3", new HashMap<>()));
+        Deck deck = new Deck(cards);
+        Card card1 = deck.peek(1);
+        assertEquals(new ChanceCard(Action.DirectMove, "Test card 2", new HashMap<>()), card1);
+        assertEquals(3, deck.size());
+    }
+
+    @Test
+    public void testAddToBottom() {
+        ArrayList<Card> cards = new ArrayList<>();
+        cards.add(new ChanceCard(Action.Advance, "Test card 1", new HashMap<>()));
+        cards.add(new ChanceCard(Action.DirectMove, "Test card 2", new HashMap<>()));
+        cards.add(new ChanceCard(Action.DirectMove, "Test card 3", new HashMap<>()));
+        Deck deck = new Deck(cards);
+        deck.addToBottom(new ChanceCard(Action.DirectMove, "Test card 4", new HashMap<>()));
+        assertEquals(4, deck.size());
+        assertEquals(new ChanceCard(Action.DirectMove, "Test card 4", new HashMap<>()), deck.getDeck().get(3));
+    }
+
+    @Test
+    public void testAddToTop() {
+        ArrayList<Card> cards = new ArrayList<>();
+        cards.add(new ChanceCard(Action.Advance, "Test card 1", new HashMap<>()));
+        cards.add(new ChanceCard(Action.DirectMove, "Test card 2", new HashMap<>()));
+        cards.add(new ChanceCard(Action.DirectMove, "Test card 3", new HashMap<>()));
+        Deck deck = new Deck(cards);
+        deck.addToTop(new ChanceCard(Action.DirectMove, "Test card 4", new HashMap<>()));
+        assertEquals(4, deck.size());
+        assertEquals(new ChanceCard(Action.DirectMove, "Test card 4", new HashMap<>()), deck.getDeck().getFirst());
+    }
+
+    @Test
+    public void testRemoveCard() {
+        ArrayList<Card> cards = new ArrayList<>();
+        cards.add(new ChanceCard(Action.Advance, "Test card 1", new HashMap<>()));
+        cards.add(new ChanceCard(Action.DirectMove, "Test card 2", new HashMap<>()));
+        cards.add(new ChanceCard(Action.DirectMove, "Test card 3", new HashMap<>()));
+        Deck deck = new Deck(cards);
+        assertTrue(deck.removeCard(new ChanceCard(Action.DirectMove, "Test card 2", new HashMap<>())));
+        assertEquals(2, deck.size());
+        assertEquals(new ChanceCard(Action.Advance, "Test card 1", new HashMap<>()), deck.peek());
+        assertEquals(new ChanceCard(Action.DirectMove, "Test card 3", new HashMap<>()), deck.peek(1));
+    }
+}


### PR DESCRIPTION
- Updates `Card` class to have hash function and equals (was a pain to test without these and every class really should have these defined anyways)
- Introduces new `Deck` class which can store anything that extends the `Card` class (chance, community, or property in future)
  - Deck implements several functions that we will need in game. Think shuffle, draw (from top), etc.
  - There's also a number of helper functions for tests later down the line when we need to manipulate the state to get a certain testing scenario. Think `peek(index)`, `remove(Card c)`, `size`, etc.
- Adds in `Deck` test suite