### PR TITLE
Add chance/community card displays; Fix infinite loop when invalid ch…

### DIFF
--- a/monopoly/src/main/java/gameset/cards/ChanceCard.java
+++ b/monopoly/src/main/java/gameset/cards/ChanceCard.java
@@ -31,4 +31,11 @@ public class ChanceCard extends Card {
             }
         }
     }
+
+    @Override
+    public String toString() {
+        return "Chance" +
+                System.lineSeparator() +
+                this.description;
+    }
 }

--- a/monopoly/src/main/java/gameset/cards/CommunityChestCard.java
+++ b/monopoly/src/main/java/gameset/cards/CommunityChestCard.java
@@ -31,4 +31,11 @@ public class CommunityChestCard extends Card {
             }
         }
     }
+
+    @Override
+    public String toString() {
+        return "Community Chest" +
+                System.lineSeparator() +
+                this.description;
+    }
 }

--- a/monopoly/src/main/java/gameset/functionality/Game.java
+++ b/monopoly/src/main/java/gameset/functionality/Game.java
@@ -1,5 +1,7 @@
 package gameset.functionality;
 
+import gameset.cards.ChanceCard;
+import gameset.cards.CommunityChestCard;
 import gameset.screens.GameScreen;
 import gameutils.Ansi;
 
@@ -40,10 +42,10 @@ public class Game {
         System.out.println("Your balance is: " + Ansi.ANSI_GREEN + player.getMoney() + Ansi.ANSI_RESET);
         System.out.println("Press P to purchase: ");
         System.out.println("Press F to skip: ");
-        String input = userInput.next();
         System.out.println("******************");
         boolean flag = false;
         while (!flag) {
+            String input = userInput.next();
             if (input.equals("P") || input.equals("p")) {
                 if (player.checkBalance(property.getPrice())) {
                     player.addProperty(property);
@@ -104,8 +106,20 @@ public class Game {
             case "property" -> viewProperty(board.getGameBoard().get(landingSpot), player);
             case "railroad" -> System.out.println("Landed on a railroad");
             case "tax" -> System.out.println("Landed on tax");
-            // TODO: GH issue #28 (Chance/Community card display - implement around here)
-            case "card" -> System.out.println("Landed on a card");
+            case "card" -> {
+                switch (property.getName().toLowerCase()) {
+                    case "chance" -> {
+                        ChanceCard c = board.getChanceCards().draw();
+                        System.out.println(c);
+                        c.applyEffect(player, this);
+                    }
+                    case "community" -> {
+                        CommunityChestCard c = board.getCommunityChestCards().draw();
+                        System.out.println(c);
+                        c.applyEffect(player, this);
+                    }
+                }
+            }
             default -> System.out.println("Landed on a space");
         }
         System.out.println("---------------");
@@ -186,7 +200,6 @@ public class Game {
         if (player.getJailStatus()) {
             handlePlayerInJail(player);
         } else {
-            // TODO: GH issue #27 (Chance/Community card drawing - implement around here)
             int landingSpot = getLandingSpot(player, board);
             player.updatePosition(landingSpot);
             board.setPlayerPosition(player);

--- a/monopoly/src/main/java/gameset/functionality/Game.java
+++ b/monopoly/src/main/java/gameset/functionality/Game.java
@@ -113,7 +113,7 @@ public class Game {
                         System.out.println(c);
                         c.applyEffect(player, this);
                     }
-                    case "community" -> {
+                    case "community chest" -> {
                         CommunityChestCard c = board.getCommunityChestCards().draw();
                         System.out.println(c);
                         c.applyEffect(player, this);

--- a/monopoly/src/main/resources/models/propertyData.json
+++ b/monopoly/src/main/resources/models/propertyData.json
@@ -251,7 +251,7 @@
   },
   {
     "name": "Community Chest",
-    "type": "space",
+    "type": "card",
     "price": 0,
     "color": "",
     "rentWithBuildingsList": [0]

--- a/monopoly/src/test/java/gameset/cards/ChanceCardTest.java
+++ b/monopoly/src/test/java/gameset/cards/ChanceCardTest.java
@@ -24,4 +24,13 @@ public class ChanceCardTest {
         assertEquals(description, card.description);
         assertEquals(params, card.params);
     }
+
+    @Test
+    public void testToString() {
+        Action action = Action.Advance;
+        String description = "Advance to Go (Collect $200)";
+        Map<String, Object> params = new HashMap<>();
+        ChanceCard card = new ChanceCard(action, description, params);
+        assertEquals("Chance\nAdvance to Go (Collect $200)", card.toString());
+    }
 }

--- a/monopoly/src/test/java/gameset/cards/CommunityChestCardTest.java
+++ b/monopoly/src/test/java/gameset/cards/CommunityChestCardTest.java
@@ -24,6 +24,14 @@ public class CommunityChestCardTest {
         assertEquals(description, card.description);
         assertEquals(params, card.params);
     }
-    // TODO: GH issue #28 - test displaying card information
+
+    @Test
+    public void testToString() {
+        Action action = Action.Advance;
+        String description = "Advance to Go (Collect $200)";
+        Map<String, Object> params = new HashMap<>();
+        CommunityChestCard card = new CommunityChestCard(action, description, params);
+        assertEquals("Community Chest\nAdvance to Go (Collect $200)", card.toString());
+    }
     // TODO: GH issue #29, 30, 31 - test applyEffect
 }

--- a/monopoly/src/test/java/gameset/functionality/DeckTest.java
+++ b/monopoly/src/test/java/gameset/functionality/DeckTest.java
@@ -1,9 +1,8 @@
-package gameset.functionality.deck;
+package gameset.functionality;
 
 import gameset.cards.Action;
 import gameset.cards.Card;
 import gameset.cards.ChanceCard;
-import gameset.functionality.Deck;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;

--- a/monopoly/src/test/java/gameset/functionality/GameTest.java
+++ b/monopoly/src/test/java/gameset/functionality/GameTest.java
@@ -1,0 +1,17 @@
+package gameset.functionality;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+// TODO: GH #24 - Refactor how Game works - almost impossible to test due to the current design. If handle player is
+// truly a private, then we need some public method that we can test easier
+public class GameTest {
+    @Test
+    public void testHandlePlayerLandOnChance() {
+        assertTrue(true);
+    }
+
+    @Test
+    public void testHandlePlayerLandOnCommunityChest() {
+        assertTrue(true);
+    }
+}


### PR DESCRIPTION
This PR addresses the following:
- Creates displays for chance and community cards (by pulling from respective decks)
- Corrects infinite loop error when invalid input is hit on purchase property screen

_NOTE_: Skipping tests for now as a refactor of `Game` class feels necessary before getting into writing tests for how card displays/etc

Demo:

## Hitting a Chance card
![Screenshot 2025-02-20 at 7 08 46 PM](https://github.com/user-attachments/assets/f0330854-42bb-4bb2-a209-8b1eabe182f6)

## Hitting a Community Chest card
![Screenshot 2025-02-20 at 7 27 07 PM](https://github.com/user-attachments/assets/54205770-e76f-4c79-bf1d-62ca770bd168)
